### PR TITLE
修正一个bug，在jq3环境下，调整layer宽高时iframe的高度并不会变化。

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -773,7 +773,7 @@ layer.style = function(index, options, limit){
   }
   
   layero.css(options);
-  btnHeight = layero.find('.'+doms[6]).outerHeight();
+  btnHeight = layero.find('.'+doms[6]).outerHeight()||0; //bug fix from Yuri2 (undefined btnHeight in jq3)
   
   if(type === ready.type[2]){
     layero.find('iframe').css({


### PR DESCRIPTION
修正方案：btnHeight的赋值末尾加上 ||0 防止出现undefined
Signed-off-by: Yuri2 <824831811@qq.com>